### PR TITLE
fix: chatgptにわたす引数を修正

### DIFF
--- a/genieslack/main.py
+++ b/genieslack/main.py
@@ -42,7 +42,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event):
                 timestamp=item["ts"],
                 name=reaction
             )
-            message = response["message"]
+            message = response["message"]['text']
 
             # メッセージを要約
             summarized_message_gift = chatgpt.summarize_message(message)


### PR DESCRIPTION
# 概要
- いままでchatgptに message (dict) を渡していたのを message.text (str) に変更
- https://api.slack.com/methods/reactions.get