### PR TITLE
nginxによるhttpsリバースプロキシを構築

### DIFF
--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -1,0 +1,6 @@
+FROM certbot/certbot:v2.6.0
+
+COPY ./certbot.sh /certbot.sh
+RUN chmod +x /certbot.sh
+
+ENTRYPOINT ["/certbot.sh"]

--- a/certbot/certbot.sh
+++ b/certbot/certbot.sh
@@ -3,6 +3,6 @@
 trap exit TERM
 while :; do 
     certbot renew -w /var/www/certbot --post-hook "nginx -s reload" --quiet
-    sleep 7w &
+    sleep 7d &
     wait $!
 done

--- a/certbot/certbot.sh
+++ b/certbot/certbot.sh
@@ -2,7 +2,7 @@
 
 trap exit TERM
 while :; do 
-    certbot renew -w /var/www/certbot --post-hook "nginx -s reload" --quiet
+    certbot renew -w /var/www/certbot --quiet
     sleep 7d &
     wait $!
 done

--- a/certbot/certbot.sh
+++ b/certbot/certbot.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+trap exit TERM
+while :; do 
+    certbot renew -w /var/www/certbot --post-hook "nginx -s reload" --quiet
+    sleep 7w &
+    wait $!
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,27 @@ services:
     build: ./slack-event-server
     volumes:
       - ./slack-event-server:/app/slack-event-server
+    expose:
+      - "3000"
+    networks:
+      - app_bridge
+  nginx:
+    build: ./nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - ./certbot/www/certbot:/var/www/certbot
+    networks:
+      - app_bridge
+  certbot:
+    build: certbot/certbot:v2.6.0
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew -w /var/www/certbot; sleep 7d & wait $${!}; done;'"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - ./certbot/www/certbot:/var/www/certbot
+
+networks:
+  app_bridge:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@ services:
     networks:
       - app_bridge
   certbot:
-    build: certbot/certbot:v2.6.0
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew -w /var/www/certbot; sleep 7d & wait $${!}; done;'"
+    build: ./certbot
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
       - ./certbot/www/certbot:/var/www/certbot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: ./slack-event-server
     volumes:
       - ./slack-event-server:/app/slack-event-server
+    env_file:
+      - .env
     expose:
       - "3000"
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,7 @@
 # nginx for https reverse proxy
 FROM nginx:1.24.0-alpine
+RUN apk add --no-cache inotify-tools
 COPY ./default.conf /etc/nginx/conf.d/default.conf
+COPY ./watch-certificate.sh /watch-certificate.sh
+RUN chmod +x /watch-certificates.sh
+CMD ["/bin/sh", "-c", "/watch-certificate.sh & nginx -g 'daemon off;'"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,12 @@
 # nginx for https reverse proxy
 FROM nginx:1.24.0-alpine
+
 RUN apk add --no-cache inotify-tools
+
 COPY ./default.conf /etc/nginx/conf.d/default.conf
+COPY ./genieslack.kusshi.dev/ /var/www/genieslack/
+
 COPY ./watch-certificate.sh /watch-certificate.sh
 RUN chmod +x /watch-certificate.sh
+
 CMD ["/bin/sh", "-c", "/watch-certificate.sh & nginx -g 'daemon off;'"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+# nginx for https reverse proxy
+FROM nginx:1.24.0-alpine
+COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,5 +3,5 @@ FROM nginx:1.24.0-alpine
 RUN apk add --no-cache inotify-tools
 COPY ./default.conf /etc/nginx/conf.d/default.conf
 COPY ./watch-certificate.sh /watch-certificate.sh
-RUN chmod +x /watch-certificates.sh
+RUN chmod +x /watch-certificate.sh
 CMD ["/bin/sh", "-c", "/watch-certificate.sh & nginx -g 'daemon off;'"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,37 @@
+server {
+    listen 443 ssl;
+    server_name genieslack.kusshi.dev;
+
+    ssl_certificate     /etc/letsencrypt/live/genieslack.kusshi.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/genieslack.kusshi.dev/privkey.pem;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # certbot
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # slack events api
+    location /slack/events {
+        proxy_pass http://slack-event-server:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# redirect http to https
+server {
+    listen 80;
+    server_name genieslack.kusshi.dev;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,9 +5,15 @@ server {
     ssl_certificate     /etc/letsencrypt/live/genieslack.kusshi.dev/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/genieslack.kusshi.dev/privkey.pem;
 
+    error_page 404 = @blank;
+
+    location @blank {
+        return 444;
+    }
+
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        root   /var/www/genieslack;
+        index  index.html;
     }
 
     # certbot

--- a/nginx/genieslack.kusshi.dev/index.html
+++ b/nginx/genieslack.kusshi.dev/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>GenieSlack</title>
+        <link rel="stylesheet" href="styles.css">
+    </head>
+    <body>
+        <div class="content">
+            <h1>GenieSlack</h1>
+        </div>
+    </body>
+</html>

--- a/nginx/genieslack.kusshi.dev/styles.css
+++ b/nginx/genieslack.kusshi.dev/styles.css
@@ -1,0 +1,13 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f0f0f0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+h1 {
+    color: #333;
+}

--- a/nginx/watch-certificate.sh
+++ b/nginx/watch-certificate.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+while inotifywait -e modify /etc/letsencrypt/live/genieslack.kusshi.dev/; do
+    nginx -s reload
+done

--- a/slack-event-server/Dockerfile
+++ b/slack-event-server/Dockerfile
@@ -24,6 +24,4 @@ RUN poetry install
 
 WORKDIR /app
 
-EXPOSE 3000/tcp
-
 CMD python genieslack/main.py

--- a/slack-event-server/Dockerfile
+++ b/slack-event-server/Dockerfile
@@ -22,6 +22,6 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 COPY ./pyproject.toml ./poetry.lock ./
 RUN poetry install
 
-WORKDIR /app
+WORKDIR /app/slack-event-server
 
 CMD python genieslack/main.py


### PR DESCRIPTION
## 概要
- nginxによるhttpsリバースプロキシでslack-event-serverをhttps化
- certbotによるサーバ証明書の自動更新機能も構築
- genieslack.kusshi.devに静的ページをテスト配置
- slack-event-serverのDockerfileを微修正
- 上記の動作確認（証明書を実際に更新した際の挙動は除く）：テストワークスペースで正常に動きます

## 実行・停止方法

実行
```
docker compose up -d [--build]
```

停止
```
docker compose down
```

## 詳細
### docker-compose.yml
- bridge networkを作成し、event server, nginx, certbotを配置
- event serverを`slack-event-server/Dockerfile`とあわせ一部修正
  - .envから環境変数を読み込む
  - ポート開放をdocker-compose.ymlに移動
  - WORKDIRをディレクトリ構成変更に合わせて修正
-nginxを追加
  - 80, 443を開放
  - certbot関連のディレクトリを、ホスト、certbotと共有
- certbotを追加
  - certbot関連のディレクトリを、ホスト、certbotと共有

### nginx/default.conf
- nginxのルーティング設定
  - events apiが使用するパス：サーバーにルーティング
  - certbotが使用するパス：certbotがchallengeに使うファイルを公開
  - ルート：静的HTMLを置いてみた

### nginx/Dockerfile
- nginxの起動と、証明書更新を監視するためのスクリプト実行

### nginx/watch-certificate.sh
- inotify-toolsで証明書を監視し、更新があったらnginxをリロードするスクリプト

### certbot/Dockerfile, certbot/cerbot.sh
- certbot renewを7日おきに実行
- 1回目に関しては正しく実行されていることを確認済み