### PR TITLE
esa API カテゴリ取得とトークン取得処理分離のための改修

### DIFF
--- a/slack-event-server/genieslack/esa_api.py
+++ b/slack-event-server/genieslack/esa_api.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import re
 from typing import List, Optional, Union
 
 import requests
@@ -233,7 +234,7 @@ def get_genieslack_categories(token: str, team_name: str) -> List[str]:
     #     GenieSlack/論文情報, ...]
     # -> [プログラミング/Python, 学会情報, 論文情報, ...]
     categories: List[str] = [
-        post['full_name'][len('GenieSlack/'):]
+        re.sub(r'^GenieSlack\/', '', post['full_name'])
         for post in posts
     ]
 

--- a/slack-event-server/genieslack/esa_api.py
+++ b/slack-event-server/genieslack/esa_api.py
@@ -1,13 +1,8 @@
 import dataclasses
 import json
-import os
 from typing import List, Optional, Union
 
 import requests
-
-from dotenv import load_dotenv
-
-load_dotenv()
 
 def get_posts(token: str, team_name: str, query: str = '') -> List[dict]:
     """記事の一覧を取得する
@@ -243,6 +238,3 @@ def get_genieslack_categories(token: str, team_name: str) -> List[str]:
     ]
 
     return categories
-
-if __name__ == '__main__':
-    print(get_genieslack_categories(os.getenv('ESA_TOKEN'), 'ylab'))

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -14,6 +14,7 @@ dotenv.load_dotenv()
 SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN")
 SLACK_APP_TOKEN = os.getenv("SLACK_APP_TOKEN")
 SLACK_SIGNING_SECRET = os.getenv("SLACK_SIGNING_SECRET")
+ESA_TOKEN = os.getenv("ESA_TOKEN")
 
 app = App (
     token=SLACK_BOT_TOKEN,
@@ -73,18 +74,18 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event):
 
 def post_message_to_esa(message: str, genre: str, team_name: str) -> str:
     # 投稿先の記事情報を取得
-    post_info_list = esa_api.get_posts(team_name, f'title:{genre}')
+    post_info_list = esa_api.get_posts(ESA_TOKEN, team_name, f'title:{genre}')
 
-    if len(post_info_list['posts']) == 0:
+    if len(post_info_list) == 0:
         # 新規投稿
-        response = esa_api.send_post(team_name, esa_api.PostedInfo(
+        response = esa_api.send_post(ESA_TOKEN, team_name, esa_api.PostedInfo(
             name=genre,
             body_md=f'# {genre}\n## {datetime.datetime.now()}\n{message}\n'
         ))
     else:
         # 追記
-        post_info = post_info_list['posts'][0]
-        response = esa_api.edit_post(team_name, post_info['number'], esa_api.EditorialInfo(
+        post_info = post_info_list[0]
+        response = esa_api.edit_post(ESA_TOKEN, team_name, post_info['number'], esa_api.EditorialInfo(
             body_md=f"{post_info['body_md']}\n## {datetime.datetime.now()}\n{message}\n"
         ))
     


### PR DESCRIPTION
## 変更点
- `esa_api` の各種関数で、トークンを引数から取得するよう変更
- 記事一覧取得関数 `get_posts()`の仕様変更
  - ページネーション処理：記事数が多い場合にも全件取得できるよう変更
  - 戻り値のListの要素を、レスポンスとして帰ってくるJsonの中の`posts`部分の要素に変更
    - `main.py` のこの変更の影響を受ける部分も併せて対応
- `get_genieslack_categories()` の追加
  - GenieSlackが分類に使用する際のカテゴリを取得する
  - `GenieSlack/` 配下の記事名を全件取得し、 `GenieSlack/` 以降のサフィックスをカテゴリとする
  - esaのカテゴリの概念とは無関係であることに注意