### PR TITLE
esaのGenieSlack/配下の記事タイトルに基づいてChatGPTで分類をする

### DIFF
--- a/slack-event-server/genieslack/chatgpt.py
+++ b/slack-event-server/genieslack/chatgpt.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import List
 
 import openai
 import dotenv
@@ -27,24 +28,23 @@ def retry_wrapper(func):
     return wrapper
 
 
-def summarize_message(message: str) -> dict:
+def summarize_message(message: str, categories: List[str]) -> dict:
+    # 要約用プロンプト
     message_prompt = f"""\
-    以下の文章を要約してください。
-    すべてmarkdown形式のリストにして出力して下さい。
-    URLがある場合は必ず含めて下さい。
-    
-    {message}
-    """
+以下の文章を要約してください。
+すべてmarkdown形式のリストにして出力して下さい。
+URLがある場合は必ず含めて下さい。
 
+{message}
+"""
+
+    # 分類用プロンプト
     genre_prompt = f"""\
-    上記の文章のジャンルを以下の中から1つ選択して下さい。
+上記の文章のジャンルを以下の中から1つ選択して下さい。
 
-    [ジャンル]
-    予定
-    論文
-    知識
-    日程調整
-    """
+[ジャンル]
+
+""" + '\n'.join(categories)
 
     # openai.ChatCompletion.create 毎にエラー処理したいのでこういう形にしています
 
@@ -93,10 +93,10 @@ git checkout -b feature/XXXX
 git branch
 ブランチを切り替える
 git checkout feature/XXX or git switch feature/XXXX\
-"""))
+""", ['日程', '研究', 'お知らせ', '技術']))
 
     print(summarize_message("""\
 明日11時から開会式なので、間に合うように、10:30目安に研究室に集合しましょう。
 勿論、調子が悪ければ決して無理せず休んでください。
 既に無理して参加してくれてると思いますが、なるべく楽しめる範囲で！頑張りましょう！\
-"""))
+""", ['日程', '研究', 'お知らせ', '技術']))

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -121,7 +121,7 @@ def post_default_posts(esa_token: str, team_name: str) -> List[str]:
             name=f'GenieSlack/{genre}',
             body_md=f'# {genre}\n'
         ))
-        urls.append(response.url)
+        urls.append(response['url'])
     return urls
 
 app.start(port=3000)

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -43,6 +43,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event):
     if reaction == "summarize":
         item = event["item"]
         try:
+            # リアクションが押されたメッセージの内容を取得
             response = client.reactions_get(
                 channel=item["channel"],
                 timestamp=item["ts"],
@@ -50,8 +51,11 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event):
             )
             message = response["message"]['text']
 
+            # esaから分類時に使用するカテゴリ一覧を取得
+            categories = esa_api.get_genieslack_categories(ESA_TOKEN, 'ylab')
+
             # メッセージを要約
-            summarized_message_gift = chatgpt.summarize_message(message)
+            summarized_message_gift = chatgpt.summarize_message(message, categories)
             summarized_message = summarized_message_gift["message"]
             genre = summarized_message_gift["genre"]
 


### PR DESCRIPTION
## 概要
- ChatGPT用プロンプトを修正し、esaからカテゴリ情報を取得して分類するところまで全て実装
- これに合わせて下記変更も行った
  - `GenieSlack/`配下に記事がない場合、デフォルト記事を作成する
  - ChatGPTがプロンプトにない分類を提案してきた場合にも、適当に投稿先を決める
- ついでに #12 も実装した