### PR TITLE
Esaのチーム選択の実装

### DIFF
--- a/dbmgr/dbmgr/mysql_driver.py
+++ b/dbmgr/dbmgr/mysql_driver.py
@@ -47,9 +47,6 @@ class MyInstallationStore(SQLAlchemyInstallationStore):
         # データベースにslack_installationsが存在しないとテーブルを作成する
         self.metadata.create_all(engine)
 
-        # TODO: 暗号化、復号化処理
-
-
 class MyOAuthStateStore(SQLAlchemyOAuthStateStore):
     
     def __init__(
@@ -115,16 +112,15 @@ class EsaDB:
         return (res[0], res[1]) if n != 0 else (None, None)
 
     # esaの認証情報を読み出す
-    def get_token(self, team_id: str) -> str:
+    def get_token_and_team_name(self, team_id: str) -> str:
         n = self.cur.execute("""
-            SELECT esa_access_token
+            SELECT esa_access_token, esa_team_name
             FROM esa_access_token
             WHERE slack_team_id = %s;
         """, (team_id, ))
 
-        token = self.cur.fetchone()[0] if n != 0 else None
-        #TODO: 復号化処理
-        return token
+        res = self.cur.fetchone()
+        return (res[0], res[1]) if n != 0 else (None, None)
     
     # esaのチーム名を取得する
     def get_esa_team_name(self, team_id: str) -> str:
@@ -136,7 +132,6 @@ class EsaDB:
         return self.cur.fetchone()[0] if n != 0 else None
 
     def insert_token(self, team_id: str, access_token: str):
-        #TODO: 暗号化処理
         self.cur.execute("""
             INSERT IGNORE INTO esa_access_token (slack_team_id, esa_access_token) VALUES (%s, %s)
             ON DUPLICATE KEY UPDATE esa_access_token = %s;

--- a/dbmgr/dbmgr/mysql_driver.py
+++ b/dbmgr/dbmgr/mysql_driver.py
@@ -138,8 +138,9 @@ class EsaDB:
     def insert_token(self, team_id: str, access_token: str):
         #TODO: 暗号化処理
         self.cur.execute("""
-            INSERT IGNORE INTO esa_access_token (slack_team_id, esa_access_token) VALUES (%s, %s);
-        """, (team_id, access_token))
+            INSERT IGNORE INTO esa_access_token (slack_team_id, esa_access_token) VALUES (%s, %s)
+            ON DUPLICATE KEY UPDATE esa_access_token = %s;
+        """, (team_id, access_token, access_token))
 
         self.conn.commit()
 

--- a/slack-event-server/genieslack/chatgpt.py
+++ b/slack-event-server/genieslack/chatgpt.py
@@ -50,6 +50,7 @@ URLがある場合は必ず含めて下さい。
 
     @retry_wrapper
     def inner_message():
+        print('Call chatgpt.summarize_message.intter_message')
         response = openai.ChatCompletion.create(
             model='gpt-3.5-turbo',
             messages=[
@@ -57,12 +58,14 @@ URLがある場合は必ず含めて下さい。
             ],
             temperature=0.25,
         )
+        print('Finish chatgpt.summarize_message.intter_message')
         return response['choices'][0]['message']['content']
 
     summarized_message = inner_message()
 
     @retry_wrapper
     def inner_genre():
+        print('Call chatgpt.summarize_message.inner_genre')
         response = openai.ChatCompletion.create(
             model='gpt-3.5-turbo',
             messages=[
@@ -72,7 +75,7 @@ URLがある場合は必ず含めて下さい。
             ],
             temperature=0.25,
         )
-
+        print('Finish chatgpt.summarize_message.inner_genre')
         return response['choices'][0]['message']['content']
 
     return {

--- a/slack-event-server/genieslack/esa_api.py
+++ b/slack-event-server/genieslack/esa_api.py
@@ -213,6 +213,30 @@ def delete_post(token: str, team_name: str, post_number: str) -> None:
 
     r.raise_for_status()
 
+
+def get_teams(token: str) -> list:
+    """ユーザの参加チームの一覧を取得
+    (https://docs.esa.io/posts/102#GET%20/v1/teams)
+
+    Args:
+        token (str): アクセストークン
+
+    Returns:
+        list: チームの名前のリスト
+    """
+    r = requests.get(
+        f"https://api.esa.io/v1/teams",
+        headers={
+            'Authorization': f"Bearer {token}",
+        },
+    )
+    r.raise_for_status()
+
+    j = json.loads(r.content)
+
+    return [item['name'] for item in j['teams']] 
+
+
 def get_genieslack_categories(token: str, team_name: str) -> List[str]:
     """GenieSlackが分類に使うカテゴリの一覧を取得
 

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -308,7 +308,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body):
         item = event["item"]
         
         # esaのトークンとワークスペース名を取得
-        slack_team_id = body['team']['id']
+        slack_team_id = body['team_id']
         with mysql_driver.EsaDB() as esa_db:
             esa_token, esa_team_name = esa_db.get_token_and_team_name(slack_team_id)
             if esa_token is None:

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -299,7 +299,7 @@ def handle_esa_team_select_modal(ack, view, say, body):
 
 
 @app.event("reaction_added")
-def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body,):
+def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body):
     # リアクションを取得
     reaction = event["reaction"]
 
@@ -348,9 +348,11 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body,):
                 categories = esa_api.get_genieslack_categories(esa_token, esa_team_name)
 
             # メッセージを要約
+            print('Start summarize')
             summarized_message_gift = chatgpt.summarize_message(message, categories)
             summarized_message = summarized_message_gift["message"]
             genre = summarized_message_gift["genre"]
+            print('Finish summarize')
 
             # ChatGPTの出力したgenreがesaのカテゴリ一覧に含まれているか確認
             if genre not in categories:

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -230,7 +230,7 @@ def show_esa_team_select_modal(ack, client, body):
             ]
         # esaのOAuth認可は完了している = esaのチーム選択ができる場合
         else:
-            team_list = ['team1', 'team2', 'team3']  # TODO: esa_access_tokenから取得
+            team_list = esa_api.get_teams(esa_access_token)
 
             show_send_btn = True
             blocks = [


### PR DESCRIPTION
# 概要
- チーム選択を追加しました
- 動作
  - 初期メッセージのボタンを押すとモーダルが開く
  - モーダルは状態によって表示するコンテンツを変える
    - esaのOAuthがまだ: エラー
    - esaのOAuth完了 and チーム選択がまだ: チーム選択画面
    - esaのOAuth完了 and チーム選択完了: エラー
  - チーム選択されたら esa_access_token に情報を保存する
- **動作が正しいか自信がないので、念のため誰かDBの状態見ながらテストして欲しい**
- コード面
  - `mysql_driver.py`: テーブル作成の修正、チーム名関係のメソッドの追加・修正
  - `esa_api.py`: チーム一覧取得用メソッド作成
  - `main.py`: 初期メッセージにモーダルへのボタンを追加、モーダルの表示用メソッドとモーダルの完了ボタンのイベント用メソッド追加、