### PR TITLE
ChatGPTのFucntion Callingに対応 + タイトルの追加

### DIFF
--- a/slack-event-server/genieslack/chatgpt.py
+++ b/slack-event-server/genieslack/chatgpt.py
@@ -61,7 +61,6 @@ def summarize_message(message: str, categories: List[str]) -> dict:
     message_prompt = f"""\
     以下の文章を要約してください。
     すべてmarkdown形式のリストにして出力して下さい。
-    URLがある場合は必ず含めて下さい。
 
     [文章]
     {message}

--- a/slack-event-server/genieslack/chatgpt.py
+++ b/slack-event-server/genieslack/chatgpt.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 from typing import List
@@ -29,22 +30,54 @@ def retry_wrapper(func):
 
 
 def summarize_message(message: str, categories: List[str]) -> dict:
+    # function calling用の関数
+    def get_summarize_info(title: str, category: str) -> dict:
+        return json.dumps({
+            'title': title,
+            'category': category,
+        })
+    
+    # 分類とタイトル用の関数
+    functions = [{
+        'name': 'get_summarize_info',
+        'description': '要約結果の情報を得る',
+        'parameters': {
+            'type': 'object',
+            'properties': {
+                'title': {
+                    'type': 'string',
+                    'description': '要約したメッセージのタイトル',
+                },
+                'category': {
+                    'type': 'string',
+                    'description': f"要約したメッセージのカテゴリ"
+                }
+            },
+            'required': ['title', 'category'],
+        }
+    }]
+
     # 要約用プロンプト
     message_prompt = f"""\
-以下の文章を要約してください。
-すべてmarkdown形式のリストにして出力して下さい。
-URLがある場合は必ず含めて下さい。
+    以下の文章を要約してください。
+    すべてmarkdown形式のリストにして出力して下さい。
+    URLがある場合は必ず含めて下さい。
 
-{message}
-"""
+    [文章]
+    {message}
+    """
 
-    # 分類用プロンプト
-    genre_prompt = f"""\
-上記の文章のジャンルを以下の中から1つ選択して下さい。
+    # 分類とタイトル用プロンプト
+    genre_title_prompt = f"""
+    以下の文章のタイトルとジャンルを教えて下さい。
+    文章のジャンルを以下の中から1つ選択してください。
 
-[ジャンル]
+    [文章]
+    {message}
 
-""" + '\n'.join(categories)
+    [ジャンル]
+    {categories}
+    """
 
     # openai.ChatCompletion.create 毎にエラー処理したいのでこういう形にしています
 
@@ -52,7 +85,7 @@ URLがある場合は必ず含めて下さい。
     def inner_message():
         print('Call chatgpt.summarize_message.intter_message')
         response = openai.ChatCompletion.create(
-            model='gpt-3.5-turbo',
+            model='gpt-3.5-turbo-0613',
             messages=[
                 {'role': 'user', 'content': message_prompt},
             ],
@@ -61,27 +94,26 @@ URLがある場合は必ず含めて下さい。
         print('Finish chatgpt.summarize_message.intter_message')
         return response['choices'][0]['message']['content']
 
-    summarized_message = inner_message()
-
     @retry_wrapper
     def inner_genre():
         print('Call chatgpt.summarize_message.inner_genre')
         response = openai.ChatCompletion.create(
-            model='gpt-3.5-turbo',
+            model='gpt-3.5-turbo-0613',
             messages=[
-                {'role': 'user', 'content': message_prompt},
-                {'role': 'system', 'content': summarized_message},
-                {'role': 'user', 'content': genre_prompt},
+                {'role': 'user', 'content': genre_title_prompt},
             ],
             temperature=0.25,
+            functions=functions,
+            function_call='auto',
         )
         print('Finish chatgpt.summarize_message.inner_genre')
-        return response['choices'][0]['message']['content']
+        return response['choices'][0]['message']['function_call']['arguments']
 
-    return {
-        'message': summarized_message,
-        'genre': inner_genre(),
-    }
+    result_text = inner_genre()
+    result = json.loads(result_text)
+    result['message'] = inner_message()
+
+    return result
 
 
 if __name__ == '__main__':

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -477,6 +477,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body):
             # メッセージを要約
             print('Start summarize')
             summarized_message_gift = chatgpt.summarize_message(message, categories)
+            title = summarized_message_gift['title']
             summarized_message = summarized_message_gift["message"]
             genre = summarized_message_gift["genre"]
             print('Finish summarize')
@@ -487,7 +488,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body):
                 genre = categories[0]
 
             # 要約したメッセージを投稿
-            url = post_message_to_esa(esa_token, esa_team_name, summarized_message, genre)
+            url = post_message_to_esa(esa_token, esa_team_name, title, summarized_message, genre)
 
             # urlをprint
             print(url)
@@ -503,7 +504,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body):
             print("Error: {}".format(e))
 
 
-def post_message_to_esa(token: str, team_name: str, message: str, genre: str) -> str:
+def post_message_to_esa(token: str, team_name: str, title: str, message: str, genre: str) -> str:
     """要約したメッセージをesa記事に追記する
 
     Args:
@@ -517,9 +518,6 @@ def post_message_to_esa(token: str, team_name: str, message: str, genre: str) ->
     """
     # 投稿先の記事情報を取得
     post_info_list = esa_api.get_posts(token, team_name, f'title:{genre}')
-
-    # 見出しとして使う時刻情報を取得
-    title = str(datetime.datetime.now())
 
     # 追記する
     post_info = post_info_list[0]

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -519,6 +519,10 @@ def post_message_to_esa(token: str, team_name: str, title: str, message: str, ge
     # 投稿先の記事情報を取得
     post_info_list = esa_api.get_posts(token, team_name, f'title:{genre}')
 
+    # タイトルに日時を追加
+    dt_str = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    title = f"{dt_str} {title}"
+
     # 追記する
     post_info = post_info_list[0]
     response = esa_api.edit_post(token, team_name, post_info['number'], esa_api.EditorialInfo(

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -479,7 +479,7 @@ def reaction_summarize(client: slack_sdk.web.client.WebClient, event, body):
             summarized_message_gift = chatgpt.summarize_message(message, categories)
             title = summarized_message_gift['title']
             summarized_message = summarized_message_gift["message"]
-            genre = summarized_message_gift["genre"]
+            genre = summarized_message_gift["category"]
             print('Finish summarize')
 
             # ChatGPTの出力したgenreがesaのカテゴリ一覧に含まれているか確認

--- a/slack-event-server/genieslack/main.py
+++ b/slack-event-server/genieslack/main.py
@@ -529,8 +529,6 @@ def post_message_to_esa(token: str, team_name: str, title: str, message: str, ge
         body_md=f"{post_info['body_md']}\n## {title}\n{message}\n"
     ))
 
-    # HACK: 同じ名前の見出しが複数ある場合、一番上のものに飛んでしまう
-    # 現在の実装ではは時刻情報を見出しとして使うため、重複しないことを想定している
     return f"{response['url']}#{parse.quote(title)}"
 
 


### PR DESCRIPTION
# 概要
- ChatGPTにメッセージからタイトルを生成してもらうように変更
- ChatGPTの新機能 Function Calling に対応し、ジャンルとタイトルを構造的に出力するようにした
- esaのメッセージタイトルをChatGPTが生成したタイトルに変更

# 問題
- esaでh2タグのタイトルが衝突する可能性があり、衝突するとslackに貼られているesaのリンクが正しく機能しない可能性がある