### PR TITLE
fix: Fix chatgpt error

### DIFF
--- a/slack-event-server/genieslack/chatgpt.py
+++ b/slack-event-server/genieslack/chatgpt.py
@@ -16,7 +16,7 @@ def retry_wrapper(func):
             try:
                 value = func(*args, **kwargs)
                 break
-            except (openai.error.RateLimitError, openai.error.APIConnectionError):
+            except (openai.error.RateLimitError, openai.error.APIConnectionError, openai.error.ServiceUnavailableError):
                 print('retry: sleep 20s')
                 time.sleep(20)
                 continue


### PR DESCRIPTION
- `openai.error.ServiceUnavailableError` を処理するエラーに追加